### PR TITLE
change default config

### DIFF
--- a/Source/config/connector.json
+++ b/Source/config/connector.json
@@ -1,9 +1,9 @@
 {
-    "sampling": 5000,
+    "sampling": 10000,
     "pingAddress": "8.8.8.8",
-    "pingTimeout": 120,
+    "pingTimeout": 5000,
     "dataTrafficScraper": {
-        "ip": "host.docker.internal",
+        "ip": "127.0.0.1",
         "port": "8888",
         "scrapingInterval": 10000
     }


### PR DESCRIPTION
## Summary

Update default config file-

### Added

- Describe the added features

### Changed

- sampling set to 10 s
- ping timeout set to 5 s 
- dataTrafficScraper.Ip changed from host.docker.internal to 127.0.0.1 
